### PR TITLE
Specify version in API urls in activation email

### DIFF
--- a/ocd_frontend/rest/templates/activate_email.txt
+++ b/ocd_frontend/rest/templates/activate_email.txt
@@ -4,12 +4,12 @@ U heeft zich aangemeld om een e-mail te ontvangen wanneer er nieuwe zoekresultat
 
 Klik op de onderstaande link om te bevestigen dat u deze meldingen wilt ontvangen:
 
-https://api.waaroverheid.nl/subscription/{{ doc_type }}/{{ token }}/activate
+https://api.waaroverheid.nl/v0/subscription/{{ doc_type }}/{{ token }}/activate
 
 Om u meldingen te kunnen sturen hebben we uw mailadres opgeslagen.
 In het geval dat u de meldingen wilt stopzetten en uw mailadres wilt verwijderen uit onze database, gebruik de volgende link:
 
-https://api.waaroverheid.nl/subscription/{{ doc_type }}/{{ token }}/delete
+https://api.waaroverheid.nl/v0/subscription/{{ doc_type }}/{{ token }}/delete
 
 Wanneer en hoe vaak u deze meldingen zult ontvangen is afhankelijk van de gemeente die de raadsinformatie aanlevert,
 en van de filters die u bij deze zoekopdracht hebt ingesteld.


### PR DESCRIPTION
The version url prefix is needed to distinguish between requests for the WO and ORI APIs.